### PR TITLE
Fix numbering of generated variables

### DIFF
--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -161,9 +161,9 @@ abstract class Module {
               '(${connections.join(', ')});');
     }
 
-    String parseProcedure(Procedure procedure) {
-      var partCounter = 0;
+    var partCounter = 0;
 
+    String parseProcedure(Procedure procedure) {
       ({String basic, List<String> auxiliaries}) parseVaria(Var varia) {
         late final String basic;
         final auxiliaries = <String>[];


### PR DESCRIPTION
Move the counter variable used to generate names to the scope of the `emit` function. So it will be consistently used to generate all procedures.