### PR TITLE
Fix code formatting

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -62,9 +62,9 @@ class Counter4Bit extends Module {
         reset,
         then: [value.assign(Const(0, width: 4))],
         orElse: [
-          If(enable, then: [value.assign(value.add(Const(1, width: 4)))])
+          If(enable, then: [value.assign(value.add(Const(1, width: 4)))]),
         ],
-      )
+      ),
     ]);
   }
 

--- a/example/mux2to1.dart
+++ b/example/mux2to1.dart
@@ -57,7 +57,7 @@ class Mux2to1 extends Module {
       // --------------
       // The type of assignment (blocking or non-blocking) depends
       // on the type of procedure.
-      If(sel, then: [y.assign(a)], orElse: [y.assign(b)])
+      If(sel, then: [y.assign(a)], orElse: [y.assign(b)]),
     ]);
   }
 

--- a/example/mux2to1_testbench.dart
+++ b/example/mux2to1_testbench.dart
@@ -82,7 +82,7 @@ class Mux2to1Testbench extends Module {
       b.assign(Const(1)),
       sel.assign(Const(1)),
       Delay(1),
-      Assert(y.eq(Const(1)))
+      Assert(y.eq(Const(1))),
     ]);
   }
 }

--- a/example/utf8decoder.dart
+++ b/example/utf8decoder.dart
@@ -66,7 +66,7 @@ class UTF8Decoder extends Module {
           bytesNeeded.assign(Const(0, width: 2)),
           lowerBoundary.assign(Const(0x80, width: 8)),
           upperBoundary.assign(Const(0xBF, width: 8)),
-          status.assign(Const(UTF8Decoder.statusInitial, width: 3))
+          status.assign(Const(UTF8Decoder.statusInitial, width: 3)),
         ],
         orElse: [
           If(
@@ -85,7 +85,7 @@ class UTF8Decoder extends Module {
                           codepoint.assign(Const(0, width: 13).cat(byte)),
                           status.assign(
                             Const(UTF8Decoder.statusSuccess, width: 3),
-                          )
+                          ),
                         ],
                       ),
                       Iff(
@@ -100,7 +100,7 @@ class UTF8Decoder extends Module {
                           ),
                           status.assign(
                             Const(UTF8Decoder.statusInprocess, width: 3),
-                          )
+                          ),
                         ],
                       ),
                       Iff(
@@ -115,9 +115,9 @@ class UTF8Decoder extends Module {
                               If(
                                 byte.eq(Const(0xED, width: 8)),
                                 then: [
-                                  upperBoundary.assign(Const(0x9F, width: 8))
+                                  upperBoundary.assign(Const(0x9F, width: 8)),
                                 ],
-                              )
+                              ),
                             ],
                           ),
                           bytesNeeded.assign(Const(2, width: 2)),
@@ -127,7 +127,7 @@ class UTF8Decoder extends Module {
                           ),
                           status.assign(
                             Const(UTF8Decoder.statusInprocess, width: 3),
-                          )
+                          ),
                         ],
                       ),
                       Iff(
@@ -142,9 +142,9 @@ class UTF8Decoder extends Module {
                               If(
                                 byte.eq(Const(0xF4, width: 8)),
                                 then: [
-                                  upperBoundary.assign(Const(0x8F, width: 8))
+                                  upperBoundary.assign(Const(0x8F, width: 8)),
                                 ],
-                              )
+                              ),
                             ],
                           ),
                           bytesNeeded.assign(Const(3, width: 2)),
@@ -154,14 +154,14 @@ class UTF8Decoder extends Module {
                           ),
                           status.assign(
                             Const(UTF8Decoder.statusInprocess, width: 3),
-                          )
+                          ),
                         ],
-                      )
+                      ),
                     ],
                     orElse: [
-                      status.assign(Const(UTF8Decoder.statusFailure, width: 3))
+                      status.assign(Const(UTF8Decoder.statusFailure, width: 3)),
                     ],
-                  )
+                  ),
                 ],
                 orElse: [
                   If(
@@ -182,12 +182,12 @@ class UTF8Decoder extends Module {
                           bytesSeen.assign(Const(0, width: 2)),
                           status.assign(
                             Const(UTF8Decoder.statusSuccess, width: 3),
-                          )
+                          ),
                         ],
                         orElse: [
-                          bytesSeen.assign(bytesSeen.add(Const(1, width: 2)))
+                          bytesSeen.assign(bytesSeen.add(Const(1, width: 2))),
                         ],
-                      )
+                      ),
                     ],
                     orElse: [
                       codepoint.assign(Const(0, width: 21)),
@@ -197,15 +197,15 @@ class UTF8Decoder extends Module {
                       upperBoundary.assign(Const(0xBF, width: 8)),
                       status.assign(
                         Const(UTF8Decoder.statusFailureRepeat, width: 3),
-                      )
+                      ),
                     ],
-                  )
+                  ),
                 ],
-              )
+              ),
             ],
-          )
+          ),
         ],
-      )
+      ),
     ]);
   }
 

--- a/example/utf8decoder_testbench.dart
+++ b/example/utf8decoder_testbench.dart
@@ -143,7 +143,7 @@ class UTF8DecoderTestbench extends Module {
           }
         }
         return actions;
-      }()
+      }(),
     ]);
   }
 }

--- a/example/utf8encoder.dart
+++ b/example/utf8encoder.dart
@@ -86,7 +86,7 @@ class UTF8Encoder extends Module {
               count.assign(Const(3, width: 2)),
               offset.assign(Const(0xF0, width: 8)),
             ],
-          )
+          ),
         ],
         orElse: [status.assign(Const(UTF8Encoder.statusFailure))],
       ),
@@ -144,13 +144,13 @@ class UTF8Encoder extends Module {
                         .part(7, 0),
                   ),
                   bytes.assign(byte.cat(bytes.part(23, 0))),
-                  status.assign(Const(UTF8Encoder.statusSuccess))
+                  status.assign(Const(UTF8Encoder.statusSuccess)),
                 ],
-              )
+              ),
             ],
-          )
+          ),
         ],
-      )
+      ),
     ]);
   }
 

--- a/example/utf8encoder_testbench.dart
+++ b/example/utf8encoder_testbench.dart
@@ -39,7 +39,7 @@ class UTF8EncoderTestbench extends Module {
       ...[
         codepoint.assign(Const(0x110000, width: 21)),
         Delay(1),
-        Assert(status.eq(Const(UTF8Encoder.statusFailure)))
+        Assert(status.eq(Const(UTF8Encoder.statusFailure))),
       ],
       // Let's generate test values from an external file.
       // Used "UTF-8 encoded sample plain-text file"
@@ -63,7 +63,7 @@ class UTF8EncoderTestbench extends Module {
             codepoint.assign(Const(testCodepoint, width: 21)),
             Delay(1),
             Assert(status.eq(Const(UTF8Encoder.statusSuccess))),
-            Assert(bytes.eq(Const(expectedOutput, width: 32)))
+            Assert(bytes.eq(Const(expectedOutput, width: 32))),
           ]);
         }
         return actions;
@@ -86,11 +86,11 @@ class UTF8EncoderTestbench extends Module {
             codepoint.assign(Const(testCodepoint, width: 21)),
             Delay(1),
             Assert(status.eq(Const(UTF8Encoder.statusSuccess))),
-            Assert(bytes.eq(Const(expectedOutput, width: 32)))
+            Assert(bytes.eq(Const(expectedOutput, width: 32))),
           ]);
         }
         return actions;
-      }()
+      }(),
     ]);
   }
 }

--- a/lib/src/module.dart
+++ b/lib/src/module.dart
@@ -140,7 +140,7 @@ abstract class Module {
         for (final varia in [
           ...this.inputs,
           ...this.outputs,
-          ...this.internals
+          ...this.internals,
         ]) {
           if (input.drivers.contains(varia)) {
             connections.add('.${input.name}(${varia.name})');
@@ -229,7 +229,7 @@ abstract class Module {
             }
             auxiliaries.insertAll(0, [
               ...parsedVaria.auxiliaries,
-              '  logic$width$name = ${parsedVaria.basic};'
+              '  logic$width$name = ${parsedVaria.basic};',
             ]);
             if (bypassPartSelect) {
               final auxiliaryDeclarations = <String>[];
@@ -304,8 +304,8 @@ abstract class Module {
           final basics = [
             [
               '${assignment.destination.name} $assignmentOperator ',
-              '${parsedVaria.basic};'
-            ].join()
+              '${parsedVaria.basic};',
+            ].join(),
           ];
           final auxiliaries = parsedVaria.auxiliaries;
           if (procedure is Combinational) {
@@ -540,7 +540,7 @@ abstract class Module {
           syncSequentials.join('\n').isNotEmpty)
         '\n',
       syncSequentials.join('\n'),
-      'endmodule\n'
+      'endmodule\n',
     ];
     return result.join();
   }

--- a/lib/src/tools.dart
+++ b/lib/src/tools.dart
@@ -30,7 +30,7 @@ class IcarusVerilog {
       '-Winfloop',
       '-Wsensitivity-entire-vector',
       '-Wfloating-nets',
-      '-s$topModule'
+      '-s$topModule',
     ];
     final result =
         Process.runSync('iverilog', [...setup, inputFile, '-o$outputFile']);

--- a/lib/src/utilities/keywords.dart
+++ b/lib/src/utilities/keywords.dart
@@ -258,6 +258,6 @@ abstract class Keywords {
     'within',
     'wor',
     'xnor',
-    'xor'
+    'xor',
   ];
 }


### PR DESCRIPTION
Dart 3.1 tightened up the `require_trailing_commas` rule check.